### PR TITLE
Fix panic when sending to JS returns error.

### DIFF
--- a/src/views/chart.rs
+++ b/src/views/chart.rs
@@ -16,7 +16,9 @@ pub fn eval_chart1() {
 
     spawn(async move {
         sleep_ms(1000).await;
-        _eval.send((vec![148, 150, 130, 170]).into()).unwrap();
+        if let Err(err) = _eval.send((vec![148, 150, 130, 170]).into()) {
+            tracing::warn!("Sending to JS returns error: {err:?}");
+        }
     });
 }
 


### PR DESCRIPTION
Sometimes when sending data to chart1, the send operation returns an error, causing the entire program to panic. The error message is as follows:
 
```
panicked at src/views/chart.rs:19:55:
called `Result::unwrap()` on an `Err` value: Finished
```